### PR TITLE
Do not add id: null for Features

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -171,10 +171,10 @@ Feature
   >>> my_point = Point((-3.68, 40.41))
 
   >>> Feature(geometry=my_point)  # doctest: +ELLIPSIS
-  {"geometry": {"coordinates": [-3.68..., 40.4...], "type": "Point"}, "id": null, "properties": {}, "type": "Feature"}
+  {"geometry": {"coordinates": [-3.68..., 40.4...], "type": "Point"}, "properties": {}, "type": "Feature"}
 
   >>> Feature(geometry=my_point, properties={"country": "Spain"})  # doctest: +ELLIPSIS
-  {"geometry": {"coordinates": [-3.68..., 40.4...], "type": "Point"}, "id": null, "properties": {"country": "Spain"}, "type": "Feature"}
+  {"geometry": {"coordinates": [-3.68..., 40.4...], "type": "Point"}, "properties": {"country": "Spain"}, "type": "Feature"}
 
   >>> Feature(geometry=my_point, id=27)  # doctest: +ELLIPSIS
   {"geometry": {"coordinates": [-3.68..., 40.4...], "type": "Point"}, "id": 27, "properties": {}, "type": "Feature"}
@@ -195,7 +195,7 @@ FeatureCollection
   >>> my_other_feature = Feature(geometry=Point((-80.234, -22.532)))
 
   >>> FeatureCollection([my_feature, my_other_feature])  # doctest: +ELLIPSIS
-  {"features": [{"geometry": {"coordinates": [1.643..., -19.12...], "type": "Point"}, "id": null, "properties": {}, "type": "Feature"}, {"geometry": {"coordinates": [-80.23..., -22.53...], "type": "Point"}, "id": null, "properties": {}, "type": "Feature"}], "type": "FeatureCollection"}
+  {"features": [{"geometry": {"coordinates": [1.643..., -19.12...], "type": "Point"}, "properties": {}, "type": "Feature"}, {"geometry": {"coordinates": [-80.23..., -22.53...], "type": "Point"}, "properties": {}, "type": "Feature"}], "type": "FeatureCollection"}
 
 Visualize the result of the example above `here <https://gist.github.com/frewsxcv/34513be6fb492771ef7b>`__. General information about FeatureCollection can be found in `Section 2.3`_ within `The GeoJSON Format Specification`_.
 

--- a/geojson/feature.py
+++ b/geojson/feature.py
@@ -24,7 +24,8 @@ class Feature(GeoJSON):
         :rtype: Feature
         """
         super(Feature, self).__init__(**extra)
-        self["id"] = id
+        if id is not None:
+            self["id"] = id
         self["geometry"] = (self.to_instance(geometry, strict=True)
                             if geometry else None)
         self["properties"] = properties or {}

--- a/tests/test_geo_interface.py
+++ b/tests/test_geo_interface.py
@@ -46,7 +46,6 @@ class EncodingDecodingTest(unittest.TestCase):
                         'type': "Point",
                         'coordinates': self.latlng,
                     },
-                    'id': None,
                     'type': "Feature",
                     'properties': {
                         'name': self.name,
@@ -81,7 +80,6 @@ class EncodingDecodingTest(unittest.TestCase):
         self.restaurant_feature_str = ('{"geometry":'
                                        ' {"coordinates": [-54, 4],'
                                        ' "type": "Point"},'
-                                       ' "id": null,'
                                        ' "properties":'
                                        ' {"name": "In N Out Burger"},'
                                        ' "type": "Feature"}')


### PR DESCRIPTION
The GeoJSON specification (https://tools.ietf.org/html/draft-butler-geojson-05#section-2.2) states that:

> If a feature has a commonly used identifier, that identifier SHOULD be included as a member of the feature object with the name "id" and the value of this member is either a JSON string or number.

At the moment python-geojson adds id: null for every feature, unless specified. This is very problematic especially on geojson.io web service, which breaks when such features are present (https://github.com/mapbox/geojson.io/issues/450).

This is a PR to fix this behaviour.

