### PR TITLE
add validation for geojson objects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -279,6 +279,19 @@ map_coords
   >>> geojson.dumps(new_point, sort_keys=True)  # doctest: +ELLIPSIS
   '{"coordinates": [-57.905..., 18.62...], "type": "Point"}'
 
+validation
+~~~~~~~~~~
+:code:`geojson.IsValid` provides validation of GeoJSON objects.
+
+.. code:: python
+
+  >>> import geojson
+
+  >>> geojson.IsValid(geojson.Point((-3.68, 40.41)))
+  '{"valid": "yes", "message":""}'
+  >> geojson.IsValid(geojson.Point((-3.68, 40.41, 5.552)))
+  '{"valid": "no", "message": "the "coordinates" member must be a single position"}'
+
 Development
 -----------
 
@@ -292,6 +305,7 @@ Credits
 * Corey Farwell <coreyf@rwell.org>
 * Blake Grotewold <hello@grotewold.me>
 * Zsolt Ero <zsolt.ero@gmail.com>
+* Sergey Romanov <xxsmotur@gmail.com>
 
 
 .. _GeoJSON: http://geojson.org/

--- a/README.rst
+++ b/README.rst
@@ -287,10 +287,12 @@ validation
 
   >>> import geojson
 
-  >>> geojson.IsValid(geojson.Point((-3.68, 40.41)))
-  '{"valid": "yes", "message":""}'
-  >> geojson.IsValid(geojson.Point((-3.68, 40.41, 5.552)))
-  '{"valid": "no", "message": "the "coordinates" member must be a single position"}'
+  >>> validation = geojson.IsValid(geojson.Point((-3.68,40.41,25.14)))
+  >>> validation['valid']
+  'no'
+  >>> validation['message']
+  'the "coordinates" member must be a single position'
+
 
 Development
 -----------

--- a/README.rst
+++ b/README.rst
@@ -281,13 +281,13 @@ map_coords
 
 validation
 ~~~~~~~~~~
-:code:`geojson.IsValid` provides validation of GeoJSON objects.
+:code:`geojson.is_valid` provides validation of GeoJSON objects.
 
 .. code:: python
 
   >>> import geojson
 
-  >>> validation = geojson.IsValid(geojson.Point((-3.68,40.41,25.14)))
+  >>> validation = geojson.is_valid(geojson.Point((-3.68,40.41,25.14)))
   >>> validation['valid']
   'no'
   >>> validation['message']

--- a/geojson/__init__.py
+++ b/geojson/__init__.py
@@ -5,6 +5,7 @@ from geojson.geometry import MultiLineString, MultiPoint, MultiPolygon
 from geojson.geometry import GeometryCollection
 from geojson.feature import Feature, FeatureCollection
 from geojson.base import GeoJSON
+from geojson.validation import IsValid
 
 __all__ = ([dump, dumps, load, loads, GeoJSONEncoder] +
            [coords, map_coords] +

--- a/geojson/__init__.py
+++ b/geojson/__init__.py
@@ -5,7 +5,7 @@ from geojson.geometry import MultiLineString, MultiPoint, MultiPolygon
 from geojson.geometry import GeometryCollection
 from geojson.feature import Feature, FeatureCollection
 from geojson.base import GeoJSON
-from geojson.validation import IsValid
+from geojson.validation import is_valid
 
 __all__ = ([dump, dumps, load, loads, GeoJSONEncoder] +
            [coords, map_coords] +
@@ -14,4 +14,4 @@ __all__ = ([dump, dumps, load, loads, GeoJSONEncoder] +
            [GeometryCollection] +
            [Feature, FeatureCollection] +
            [GeoJSON] +
-           [IsValid])
+           [is_valid])

--- a/geojson/__init__.py
+++ b/geojson/__init__.py
@@ -13,4 +13,5 @@ __all__ = ([dump, dumps, load, loads, GeoJSONEncoder] +
            [MultiLineString, MultiPoint, MultiPolygon] +
            [GeometryCollection] +
            [Feature, FeatureCollection] +
-           [GeoJSON])
+           [GeoJSON] +
+           [IsValid])

--- a/geojson/validation.py
+++ b/geojson/validation.py
@@ -4,16 +4,16 @@ def IsValid(obj):
     result = {'valid': 'no', 'message':''}
     if isinstance(obj, geojson.LineString):
         if len(obj['coordinates']) < 2:
-            result['message'] = 'the "coordinates" member must be an array \
-                    of two or more positions'
+            result['message'] = 'the "coordinates" member must be an array ' \
+                    'of two or more positions'
             return result
 
     if isinstance(obj, geojson.MultiLineString):
         coord = obj['coordinates']
         if not isinstance(coord, list) or \
                 not all([len(ls) >= 2 for ls in coord]):
-            result['message'] = 'the "coordinates" member must be an array \
-                    of LineString coordinate arrays'
+            result['message'] = 'the "coordinates" member must be an array ' \
+                    'of LineString coordinate arrays'
             return result
     result['valid'] = 'yes'
     return result

--- a/geojson/validation.py
+++ b/geojson/validation.py
@@ -1,0 +1,20 @@
+import geojson
+
+def IsValid(obj):
+    result = {'valid': 'no', 'message':''}
+    if isinstance(obj, geojson.LineString):
+        if len(obj['coordinates']) < 2:
+            result['message'] = 'the "coordinates" member must be an array \
+                    of two or more positions'
+            return result
+
+    if isinstance(obj, geojson.MultiLineString):
+        coord = obj['coordinates']
+        if not isinstance(coord, list) or \
+                not all([len(ls) >= 2 for ls in coord]):
+            result['message'] = 'the "coordinates" member must be an array \
+                    of LineString coordinate arrays'
+            return result
+    result['valid'] = 'yes'
+    return result
+

--- a/geojson/validation.py
+++ b/geojson/validation.py
@@ -1,20 +1,97 @@
 import geojson
 
+
 def IsValid(obj):
-    result = {'valid': 'no', 'message':''}
+    """ IsValid provides validation for GeoJSON objects
+        All of error messages obtained from the offical site
+        http://geojson.org/geojson-spec.html
+
+        Args:
+            obj(geoJSON object): check validation
+
+        Returns:
+            dict of two paremeters 'valid' and 'message'.
+            In the case if geoJSON object is valid, returns
+            {valid: 'yes', message: ''}
+            If json objects is not valid, returns
+            {valid: 'no', message:'explanation, why this object is not valid'}
+
+        Example:
+            >> point = Point((10,20), (30,40))
+            >> IsValid(point)
+            >> {valid: 'yes', message: ''}
+    """
+
+    if not isinstance(obj, geojson.GeoJSON):
+        return output('this is not GeoJSON object')
+
+    if isinstance(obj, geojson.Point):
+        if len(obj['coordinates']) != 2:
+            return output('the "coordinates" member must be a single position')
+
+    if isinstance(obj, geojson.MultiPoint):
+        if checkListOfObjects(obj['coordinates'], lambda x: len(x) == 2):
+            return output(
+                'the "coordinates" member must be an array of positions'
+            )
+
     if isinstance(obj, geojson.LineString):
         if len(obj['coordinates']) < 2:
-            result['message'] = 'the "coordinates" member must be an array ' \
-                    'of two or more positions'
-            return result
+            return output('the "coordinates" member must be an array '
+                          'of two or more positions')
 
     if isinstance(obj, geojson.MultiLineString):
         coord = obj['coordinates']
-        if not isinstance(coord, list) or \
-                not all([len(ls) >= 2 for ls in coord]):
-            result['message'] = 'the "coordinates" member must be an array ' \
-                    'of LineString coordinate arrays'
-            return result
+        if checkListOfObjects(coord, lambda x: len(x) >= 2):
+            return output('the "coordinates" member must be an array '
+                          'of LineString coordinate arrays')
+
+    if isinstance(obj, geojson.Polygon):
+        coord = obj['coordinates']
+        lengths = all([len(elem) >= 4 for elem in coord])
+        if lengths is not True:
+            return output('LinearRing must contain with 4 or more positions')
+
+        isring = all([elem[0] == elem[-1] for elem in coord])
+        if isring is not True:
+            return output('The first and last positions in LinearRing'
+                          'must be equivalent')
+
+    if isinstance(obj, geojson.MultiPolygon):
+        if checkListOfObjects(obj['coordinates'],
+                              lambda x: len(x) >= 4 and x[0] == x[-1]):
+            return output('the "coordinates" member must be an array'
+                          'of Polygon coordinate arrays')
+
+    return output('')
+
+
+def checkListOfObjects(coord, pred):
+    """ This method provides checking list of geojson objects such Multipoint or
+        MultiLineString that each element of the list is valid geojson object.
+        This is helpful method for IsValid.
+
+        Args:
+            coord(list): List of coordinates
+            pred(function): Predicate to check validation of each
+            member in the coord
+
+        Returns:
+            True if list contains valid objects, False otherwise
+    """
+    return not isinstance(coord, list) or not all([pred(ls) for ls in coord])
+
+
+def output(message):
+    """ Output result for IsValid
+
+        Args:
+            message - If message is not empty,
+            object is not valid
+    """
+    result = {'valid': 'no', 'message': ''}
+    if message != '':
+        result['message'] = message
+        return result
     result['valid'] = 'yes'
     return result
-

--- a/geojson/validation.py
+++ b/geojson/validation.py
@@ -1,7 +1,7 @@
 import geojson
 
 
-def IsValid(obj):
+def is_valid(obj):
     """ IsValid provides validation for GeoJSON objects
         All of error messages obtained from the offical site
         http://geojson.org/geojson-spec.html

--- a/geojson/validation.py
+++ b/geojson/validation.py
@@ -49,11 +49,11 @@ def IsValid(obj):
     if isinstance(obj, geojson.Polygon):
         coord = obj['coordinates']
         lengths = all([len(elem) >= 4 for elem in coord])
-        if lengths is not True:
+        if lengths is False:
             return output('LinearRing must contain with 4 or more positions')
 
         isring = all([elem[0] == elem[-1] for elem in coord])
-        if isring is not True:
+        if isring is False:
             return output('The first and last positions in LinearRing'
                           'must be equivalent')
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,107 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for geojson/validation
+"""
+
+import unittest
+
+import geojson
+
+IsValid = geojson.IsValid
+YES = 'yes'
+NO = 'no'
+
+
+class TestValidationGeoJSONObject(unittest.TestCase):
+
+    def test_invalid_jsonobject(self):
+        obj = [1, 2, 3]
+        self.assertEqual(IsValid(obj)['valid'], NO)
+
+    def test_valid_jsonobject(self):
+        point = geojson.Point((-10.52, 2.33))
+        self.assertEqual(IsValid(point)['valid'], YES)
+
+
+class TestValidationPoint(unittest.TestCase):
+
+    def test_invalid_point(self):
+        point = geojson.Point((10, 20, 30))
+        self.assertEqual(IsValid(point)['valid'], NO)
+
+    def test_valid_point(self):
+        point = geojson.Point((-3.68, 40.41))
+        self.assertEqual(IsValid(point)['valid'], YES)
+
+
+class TestValidationMultipoint(unittest.TestCase):
+
+    def test_invalid_multipoint(self):
+        mpoint = geojson.MultiPoint(
+            [(3.5887, 10.44558), (2.5555, 3.887), (2.44, 3.44, 2.555)])
+        self.assertEqual(IsValid(mpoint)['valid'], NO)
+
+    def test_valid_multipoint(self):
+        mpoint = geojson.MultiPoint([(10, 20), (30, 40)])
+        self.assertEqual(IsValid(mpoint)['valid'], YES)
+
+
+class TestValidationLineString(unittest.TestCase):
+
+    def test_invalid_linestring(self):
+        ls = geojson.LineString([(8.919, 44.4074)])
+        self.assertEqual(IsValid(ls)['valid'], NO)
+
+    def test_valid_linestring(self):
+        ls = geojson.LineString([(10, 5), (4, 3)])
+        self.assertEqual(IsValid(ls)['valid'], YES)
+
+
+class TestValidationMultiLineString(unittest.TestCase):
+
+    def test_invalid_multilinestring(self):
+        mls = geojson.MultiLineString([[(10, 5), (20, 1)], []])
+        self.assertEqual(IsValid(mls)['valid'], NO)
+
+    def test_valid_multilinestring(self):
+        ls1 = [(3.75, 9.25), (-130.95, 1.52)]
+        ls2 = [(23.15, -34.25), (-1.35, -4.65), (3.45, 77.95)]
+        mls = geojson.MultiLineString([ls1, ls2])
+        self.assertEqual(IsValid(mls)['valid'], YES)
+
+
+class TestValidationPolygon(unittest.TestCase):
+
+    def test_invalid_polygon(self):
+        poly1 = geojson.Polygon(
+            [[(2.38, 57.322), (23.194, -20.28), (-120.43, 19.15)]])
+        self.assertEqual(IsValid(poly1)['valid'], NO)
+        poly2 = geojson.Polygon(
+            [[(2.38, 57.322), (23.194, -20.28),
+                (-120.43, 19.15), (2.38, 57.323)]])
+        self.assertEqual(IsValid(poly2)['valid'], NO)
+
+    def test_valid_polygon(self):
+        poly = geojson.Polygon(
+            [[(2.38, 57.322), (23.194, -20.28),
+                (-120.43, 19.15), (2.38, 57.322)]])
+        self.assertEqual(IsValid(poly)['valid'], YES)
+
+
+class TestValidationMultiPolygon(unittest.TestCase):
+
+    def test_invalid_multipolygon(self):
+        poly1 = [(2.38, 57.322), (23.194, -20.28),
+                 (-120.43, 19.15), (25.44, -17.91)]
+        poly2 = [(2.38, 57.322), (23.194, -20.28),
+                 (-120.43, 19.15), (2.38, 57.322)]
+        multipoly = geojson.MultiPolygon([poly1, poly2])
+        self.assertEqual(IsValid(multipoly)['valid'], NO)
+
+    def test_valid_multipolygon(self):
+        poly1 = [(2.38, 57.322), (23.194, -20.28),
+                 (-120.43, 19.15), (2.38, 57.322)]
+        poly2 = [(-5.34, 3.71), (28.74, 31.44), (28.55, 19.10), (-5.34, 3.71)]
+        poly3 = [(3.14, 23.17), (51.34, 27.14), (22, -18.11), (3.14, 23.17)]
+        multipoly = geojson.MultiPolygon([poly1, poly2, poly3])
+        self.assertEqual(IsValid(multipoly)['valid'], YES)

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -7,7 +7,7 @@ import unittest
 
 import geojson
 
-IsValid = geojson.IsValid
+is_valid = geojson.is_valid
 YES = 'yes'
 NO = 'no'
 
@@ -16,22 +16,22 @@ class TestValidationGeoJSONObject(unittest.TestCase):
 
     def test_invalid_jsonobject(self):
         obj = [1, 2, 3]
-        self.assertEqual(IsValid(obj)['valid'], NO)
+        self.assertEqual(is_valid(obj)['valid'], NO)
 
     def test_valid_jsonobject(self):
         point = geojson.Point((-10.52, 2.33))
-        self.assertEqual(IsValid(point)['valid'], YES)
+        self.assertEqual(is_valid(point)['valid'], YES)
 
 
 class TestValidationPoint(unittest.TestCase):
 
     def test_invalid_point(self):
         point = geojson.Point((10, 20, 30))
-        self.assertEqual(IsValid(point)['valid'], NO)
+        self.assertEqual(is_valid(point)['valid'], NO)
 
     def test_valid_point(self):
         point = geojson.Point((-3.68, 40.41))
-        self.assertEqual(IsValid(point)['valid'], YES)
+        self.assertEqual(is_valid(point)['valid'], YES)
 
 
 class TestValidationMultipoint(unittest.TestCase):
@@ -39,35 +39,35 @@ class TestValidationMultipoint(unittest.TestCase):
     def test_invalid_multipoint(self):
         mpoint = geojson.MultiPoint(
             [(3.5887, 10.44558), (2.5555, 3.887), (2.44, 3.44, 2.555)])
-        self.assertEqual(IsValid(mpoint)['valid'], NO)
+        self.assertEqual(is_valid(mpoint)['valid'], NO)
 
     def test_valid_multipoint(self):
         mpoint = geojson.MultiPoint([(10, 20), (30, 40)])
-        self.assertEqual(IsValid(mpoint)['valid'], YES)
+        self.assertEqual(is_valid(mpoint)['valid'], YES)
 
 
 class TestValidationLineString(unittest.TestCase):
 
     def test_invalid_linestring(self):
         ls = geojson.LineString([(8.919, 44.4074)])
-        self.assertEqual(IsValid(ls)['valid'], NO)
+        self.assertEqual(is_valid(ls)['valid'], NO)
 
     def test_valid_linestring(self):
         ls = geojson.LineString([(10, 5), (4, 3)])
-        self.assertEqual(IsValid(ls)['valid'], YES)
+        self.assertEqual(is_valid(ls)['valid'], YES)
 
 
 class TestValidationMultiLineString(unittest.TestCase):
 
     def test_invalid_multilinestring(self):
         mls = geojson.MultiLineString([[(10, 5), (20, 1)], []])
-        self.assertEqual(IsValid(mls)['valid'], NO)
+        self.assertEqual(is_valid(mls)['valid'], NO)
 
     def test_valid_multilinestring(self):
         ls1 = [(3.75, 9.25), (-130.95, 1.52)]
         ls2 = [(23.15, -34.25), (-1.35, -4.65), (3.45, 77.95)]
         mls = geojson.MultiLineString([ls1, ls2])
-        self.assertEqual(IsValid(mls)['valid'], YES)
+        self.assertEqual(is_valid(mls)['valid'], YES)
 
 
 class TestValidationPolygon(unittest.TestCase):
@@ -75,17 +75,17 @@ class TestValidationPolygon(unittest.TestCase):
     def test_invalid_polygon(self):
         poly1 = geojson.Polygon(
             [[(2.38, 57.322), (23.194, -20.28), (-120.43, 19.15)]])
-        self.assertEqual(IsValid(poly1)['valid'], NO)
+        self.assertEqual(is_valid(poly1)['valid'], NO)
         poly2 = geojson.Polygon(
             [[(2.38, 57.322), (23.194, -20.28),
                 (-120.43, 19.15), (2.38, 57.323)]])
-        self.assertEqual(IsValid(poly2)['valid'], NO)
+        self.assertEqual(is_valid(poly2)['valid'], NO)
 
     def test_valid_polygon(self):
         poly = geojson.Polygon(
             [[(2.38, 57.322), (23.194, -20.28),
                 (-120.43, 19.15), (2.38, 57.322)]])
-        self.assertEqual(IsValid(poly)['valid'], YES)
+        self.assertEqual(is_valid(poly)['valid'], YES)
 
 
 class TestValidationMultiPolygon(unittest.TestCase):
@@ -96,7 +96,7 @@ class TestValidationMultiPolygon(unittest.TestCase):
         poly2 = [(2.38, 57.322), (23.194, -20.28),
                  (-120.43, 19.15), (2.38, 57.322)]
         multipoly = geojson.MultiPolygon([poly1, poly2])
-        self.assertEqual(IsValid(multipoly)['valid'], NO)
+        self.assertEqual(is_valid(multipoly)['valid'], NO)
 
     def test_valid_multipolygon(self):
         poly1 = [(2.38, 57.322), (23.194, -20.28),
@@ -104,4 +104,4 @@ class TestValidationMultiPolygon(unittest.TestCase):
         poly2 = [(-5.34, 3.71), (28.74, 31.44), (28.55, 19.10), (-5.34, 3.71)]
         poly3 = [(3.14, 23.17), (51.34, 27.14), (22, -18.11), (3.14, 23.17)]
         multipoly = geojson.MultiPolygon([poly1, poly2, poly3])
-        self.assertEqual(IsValid(multipoly)['valid'], YES)
+        self.assertEqual(is_valid(multipoly)['valid'], YES)


### PR DESCRIPTION
Hi!
I notice what allows to construct object even if is not valid by specification and i created module for checking validation for objects. Now is something like a "concept"(or very restricted version), because i don't know about needs this for you. No tests and no documentation, but contains two objects ```LineString``` and ```MultiLineString```. How it works:
```python
>>> from geojson import LineString, MultiLineString, IsValid
>>> IsValid(LineString([(8.919, 44.4074), (8.923, 44.4075)]))
{'valid': 'yes', 'message': ''}
>>> IsValid(LineString([(8.919, 44.4074)]))
{'valid': 'no', 'message': 'the "coordinates" member must be an array of two or more positions'}
>>> IsValid(MultiLineString([[(10,5), (4,3)]]))
{'message': '', 'valid': 'yes'}
>>> IsValid(MultiLineString([[(10,5)]]))
{'message': 'the "coordinates" member must be an array of LineString coordinate arrays', 'valid': 'no'}
```
The messages is just a copy-paste from [specification]( http://geojson.org/geojson-spec.html#geojson-objects)
What do you think about this?
