### PR TITLE
Add validate parameter

### DIFF
--- a/geojson/geometry.py
+++ b/geojson/geometry.py
@@ -2,6 +2,7 @@ import sys
 from decimal import Decimal
 
 from geojson.base import GeoJSON
+from geojson.validation import is_valid
 
 
 class Geometry(GeoJSON):
@@ -15,7 +16,7 @@ class Geometry(GeoJSON):
     else:
         __JSON_compliant_types = (float, int, Decimal, long)  # noqa
 
-    def __init__(self, coordinates=None, crs=None, **extra):
+    def __init__(self, coordinates=None, crs=None, validate=False, **extra):
         """
         Initialises a Geometry object.
 
@@ -28,6 +29,11 @@ class Geometry(GeoJSON):
         super(Geometry, self).__init__(**extra)
         self["coordinates"] = coordinates or []
         self.clean_coordinates(self["coordinates"])
+        if validate:
+            validation = is_valid(self)
+            if validation['valid'] == 'no':
+                raise ValueError('{}: {}'.format(
+                    validation['message'], coordinates))
         if crs:
             self["crs"] = self.to_instance(crs, strict=True)
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -12,6 +12,27 @@ YES = 'yes'
 NO = 'no'
 
 
+class TestValidationGeometry(unittest.TestCase):
+
+    def test_invalid_geometry_with_validate(self):
+        self.assertRaises(
+            ValueError, geojson.Point, (10, 20, 30), validate=True)
+
+    def test_invalid_geometry_without_validate(self):
+        try:
+            geojson.Point((10, 20, 30))
+            geojson.Point((10, 20, 30), validate=False)
+        except ValueError:
+            self.fail("Point raised ValueError unexpectedly")
+
+    def test_valid_geometry(self):
+        try:
+            geojson.Point((10, 20), validate=True)
+            geojson.Point((10, 20), validate=False)
+        except ValueError:
+            self.fail("Point raised ValueError unexpectedly")
+
+
 class TestValidationGeoJSONObject(unittest.TestCase):
 
     def test_invalid_jsonobject(self):


### PR DESCRIPTION
What would you think about adding a `validate` parameter to the `Geometry` constructor?

If I was starting this library from scratch, I would make this an opt-out (i.e. I would make it `True` by default), but I guess now it would be a breaking change...