### PR TITLE
Additional functional maps for GeoJSON entities

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -288,7 +288,7 @@ coords
 map_coords
 ~~~~~~~~~~
 
-:code:`geojson.utils.map_coords` maps a function over all coordinate tuples and returns a geometry of the same type. Useful for translating a geometry in space or flipping coordinate order.
+:code:`geojson.utils.map_coords` maps a function over all coordinate values and returns a geometry of the same type. Useful for scaling a geometry.
 
 .. code:: python
 
@@ -298,6 +298,34 @@ map_coords
 
   >>> geojson.dumps(new_point, sort_keys=True)  # doctest: +ELLIPSIS
   '{"coordinates": [-57.905..., 18.62...], "type": "Point"}'
+
+map_tuples
+~~~~~~~~~~
+
+:code:`geojson.utils.map_tuples` maps a function over all coordinates and returns a geometry of the same type. Useful for changing coordinate order or applying coordinate transforms.
+
+.. code:: python
+
+  >>> import geojson
+
+  >>> new_point = geojson.utils.map_tuples(lambda c: (c[1], c[0]), geojson.Point((-115.81, 37.24)))
+
+  >>> geojson.dumps(new_point, sort_keys=True)  # doctest: +ELLIPSIS
+  '{"coordinates": [37.24..., -115.81], "type": "Point"}'
+
+map_geometries
+~~~~~~~~~~
+
+:code:`geojson.utils.map_geometries` maps a function over each geometry in the input.
+
+.. code:: python
+
+  >>> import geojson
+
+  >>> new_point = geojson.utils.map_geometries(lambda g: geojson.MultiPoint([g["coordinates"]]), geojson.GeometryCollection([geojson.Point((-115.81, 37.24))])
+
+  >>> geojson.dumps(new_point, sort_keys=True)  # doctest: +ELLIPSIS
+  '{"coordinates": [[-115.81..., 37.24...]], "type": "MultiPoint"}'
 
 validation
 ~~~~~~~~~~

--- a/geojson/utils.py
+++ b/geojson/utils.py
@@ -30,6 +30,25 @@ def map_coords(func, obj):
     Returns the mapped coordinates from a Geometry after applying the provided
     function to each dimension in tuples list (ie, linear scaling).
 
+    :param func: Function to apply to individual coordinate values independently
+    :type func: function
+    :param obj: A geometry or feature to extract the coordinates from.
+    :type obj: Point, LineString, MultiPoint, MultiLineString, Polygon,
+    MultiPolygon
+    :return: The result of applying the function to each dimension in the
+    array.
+    :rtype: list
+    :raises ValueError: if the provided object is not a Geometry.
+    """
+
+    def tuple_func(coord):
+      return tuple(map_tuples(func, coord))
+
+def map_tuples(func, obj):
+    """
+    Returns the mapped coordinates from a Geometry after applying the provided
+    function to each coordinate.
+
     :param func: Function to apply to tuples
     :type func: function
     :param obj: A geometry or feature to extract the coordinates from.
@@ -42,22 +61,50 @@ def map_coords(func, obj):
     """
 
     if obj['type'] == 'Point':
-        coordinates = tuple(map(func, obj['coordinates']))
+        coordinates = tuple(func(obj['coordinates']))
     elif obj['type'] in ['LineString', 'MultiPoint']:
-        coordinates = [tuple(map(func, c)) for c in obj['coordinates']]
+        coordinates = [tuple(func(c)) for c in obj['coordinates']]
     elif obj['type'] in ['MultiLineString', 'Polygon']:
         coordinates = [[
-            tuple(map(func, c)) for c in curve]
+            tuple(func(c)) for c in curve]
             for curve in obj['coordinates']]
     elif obj['type'] == 'MultiPolygon':
         coordinates = [[[
-            tuple(map(func, c)) for c in curve]
+            tuple(func(c)) for c in curve]
             for curve in part]
             for part in obj['coordinates']]
+    elif obj['type'] in ['Feature', 'FeatureCollection', 'GeometryCollection']:
+        return map_geometries(lambda g: map_tuples(func, g), obj)
     else:
         raise ValueError("Invalid geometry object %s" % repr(obj))
     return {'type': obj['type'], 'coordinates': coordinates}
 
+def map_geometries(func, obj):
+    """
+    Returns the result of passing every geometry in the given geojson object
+    through func.
+
+    :param func: Function to apply to tuples
+    :type func: function
+    :param obj: A geometry or feature to extract the coordinates from.
+    :type obj: GeoJSON
+    :return: The result of applying the function to each geometry
+    :rtype: list
+    :raises ValueError: if the provided object is not geojson.
+    """
+    if obj['type'] in ['Point', 'LineString', 'MultiPoint', 'MultiLineString', 'Polygon', "MultiPolygon"]:
+        return func(obj)
+    elif obj['type'] == 'GeometryCollection':
+        geoms = [func(geom) for geom in obj['geometries']]
+        return {'type': obj['type'], 'geometries': geoms}
+    elif obj['type'] == 'Feature':
+        geom = func(obj['geometry'])
+        return {'type': obj['type'], 'geometry': geom, 'properties': obj['properties']}
+    elif obj['type'] == 'FeatureCollection':
+        feats = [map_geometries(func, feat) for feat in obj['features']]
+        return {'type': obj['type'], 'features': feats}
+    else:
+        raise ValueError("Invalid GeoJSON object %s" % repr(obj))
 
 def generate_random(featureType, numberVertices=3,
                     boundingBox=[-180.0, -90.0, 180.0, 90.0]):

--- a/geojson/utils.py
+++ b/geojson/utils.py
@@ -38,7 +38,7 @@ def map_coords(func, obj):
     :return: The result of applying the function to each dimension in the
     array.
     :rtype: list
-    :raises ValueError: if the provided object is not a Geometry.
+    :raises ValueError: if the provided object is not GeoJSON.
     """
 
     def tuple_func(coord):
@@ -57,7 +57,7 @@ def map_tuples(func, obj):
     :return: The result of applying the function to each dimension in the
     array.
     :rtype: list
-    :raises ValueError: if the provided object is not a Geometry.
+    :raises ValueError: if the provided object is not GeoJSON.
     """
 
     if obj['type'] == 'Point':
@@ -95,10 +95,10 @@ def map_geometries(func, obj):
     if obj['type'] in ['Point', 'LineString', 'MultiPoint', 'MultiLineString', 'Polygon', "MultiPolygon"]:
         return func(obj)
     elif obj['type'] == 'GeometryCollection':
-        geoms = [func(geom) for geom in obj['geometries']]
+        geoms = [func(geom) if geom else None for geom in obj['geometries']]
         return {'type': obj['type'], 'geometries': geoms}
     elif obj['type'] == 'Feature':
-        geom = func(obj['geometry'])
+        geom = func(obj['geometry']) if obj['geometry'] else None
         return {'type': obj['type'], 'geometry': geom, 'properties': obj['properties']}
     elif obj['type'] == 'FeatureCollection':
         feats = [map_geometries(func, feat) for feat in obj['features']]


### PR DESCRIPTION
The [documentation for map_coords](https://pypi.python.org/pypi/geojson#map-coords) hints that it should be usable for coordinate transforms and the like, but the actual implementation only calls with individual values.  So rather than

`Point(x, y, z) => func(Point(x, y, z))`

You get

`Point(x, y, z) => Point(func(x), func(y), func(z))`

In my experience, this isn't a very useful transform.  This PR adds map_tuples (rather than map_coords to preserve compatibility) for the former use case, and map_geometries for use cases like doing a spatial intersection.