### PR TITLE
Fix type hinting for MultiPoint geometry

### DIFF
--- a/geojson/geometry.py
+++ b/geojson/geometry.py
@@ -21,7 +21,7 @@ class Geometry(GeoJSON):
         Initialises a Geometry object.
 
         :param coordinates: Coordinates of the Geometry object.
-        :type coordinates: tuple
+        :type coordinates: tuple or list of tuple
         :param crs: CRS
         :type crs: CRS object
         """


### PR DESCRIPTION
This change includes the correct docstring for use with both Point and MultiPoint geometry.

Fixes #113 

